### PR TITLE
Restore asynchronous exceptions in race

### DIFF
--- a/tests/TestUnendingRace.hs
+++ b/tests/TestUnendingRace.hs
@@ -1,0 +1,15 @@
+import Control.Exception
+import Data.Unamb
+
+fib :: Integer -> Integer
+fib n | n < 2 = 1
+fib n = fib (n-1) + fib (n-2)
+
+main :: IO ()
+main = do
+  let v1 = True
+      v2 = fib 38 `seq` False
+  putStrLn "Start"
+  v <- evaluate (unamb v1 v2)
+  print v
+  putStrLn "End. This should be instantaneous."


### PR DESCRIPTION
The two inner calls to `mask_` in `race` are unnecessary, and in fact the `mask_ x` is counterproductive, since we might throw an exception to it.