### PR TITLE
Implemented an isEvaluated function

### DIFF
--- a/unamb.cabal
+++ b/unamb.cabal
@@ -40,7 +40,7 @@ Library
   hs-Source-Dirs:      src
   Extensions:
   Build-Depends:       base >= 4 && < 5
-
+                       , ghc-heap
 --                     , tag-bits >= 0.1.1 && < 0.2
 
   Exposed-Modules:     


### PR DESCRIPTION
I don't understand what you're doing with `restartingUnsafePerformIO`,
so I left `unsafeIsEvaluated`.

I'm not sure why `unsafeIsEvaluated` exists - it is non-deterministic.
Shouldn't the `restartingUnsafePerformIO` be pushed down to the call
sites?